### PR TITLE
Add /api/getCourseDetails and logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -183,7 +183,7 @@
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
@@ -240,9 +240,9 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-      "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
@@ -2181,7 +2181,7 @@
       }
     },
     "UCI": {
-      "version": "git+https://fd4d94f1f4bc5e70e57691f4671f16ccd4a704d3:x-oauth-basic@github.com/farkam135/UCI-API.git#e65697511edb475b9473c0e0467ce57823241be9",
+      "version": "git+https://fd4d94f1f4bc5e70e57691f4671f16ccd4a704d3:x-oauth-basic@github.com/farkam135/UCI-API.git#c833e9a479bee7eae86ea0a5da5b75389ac4456b",
       "requires": {
         "cheerio": "0.22.0",
         "node-fetch": "1.7.3",
@@ -2222,7 +2222,7 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "requires": {
         "boxen": "1.2.2",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "configstore": "3.1.1",
         "import-lazy": "2.1.0",
         "is-installed-globally": "0.1.0",

--- a/server.js
+++ b/server.js
@@ -137,7 +137,7 @@ app.get('/api/getCourseDetails', (req, res) => {
 
 UCI.SOC.init()
     .then(() => {
-        return Promise.all([UCI.SOC.loadAll('COMPSCI')]);
+        return Promise.all([UCI.PROFS.refreshProfs(), UCI.SOC.loadDept('COMPSCI')]);
     })
     .then(() => {
         app.listen(8080, () => {


### PR DESCRIPTION
For issue #3 
Couple updates were made for the logic of getCourseDetails. 
First, the server was updated, now instead of just listening on port 8080 the server has to collect some data first. In the server first the UCI.SOC.init is run which gets the current year term and departments, once those are loaded both UCI.PROFS.refreshProfs() and UCI.SOC.loadAll should run, the first one pulls all professors from ratemyprofessor and loadAll loads all the metadata of courses (their names, descriptions, offering codes this quarter, prereqs). For testing purposes since it takes some time to load all the departments I went ahead and exposed the loadDept function in the UCI-API so we can just load up one department. Once that is all loaded up then the server starts listening on 8080.

Next the getCourseDetails function has a lot going on. First since it's passed a course name like "COMPSCI 161" we have to split it up by dept and num since in the db they are separate columns so I run a regex to split it and set that as the dbselectors. Then I just run both the UCI.SOC.getCourseDetails and the MYRMEYDB.getGrades, the first for the course's metadata and the second for the grade distributions. I then go through all the rows of grades returned by the db. If it finds a grade for the course with a professor that has not already been accounted for it will create a new gradeDistribution object for that professor and use the UCI.PROFS.getProfessor to get ratemyprofessor metadata for that professor. Once the gradeDistribution is created any additional grades that are for the same professor are just added to the gradeDistribution. Once all the rows are read through the gradeDistributions are just added to the course's metadata pulled from UCI.SOC.getCourseDetails.