### PR TITLE
Add /api/searchSchedule

### DIFF
--- a/server.js
+++ b/server.js
@@ -104,6 +104,26 @@ function getCourseDetails(courseName, res) {
         })
 }
 
+function searchSchedule(search, res) {
+    UCI.SOC.searchSchedule(search)
+        .then((results) => {
+            //We have the results go through and modify the instructors to add their ratemyprofessor object
+            results.forEach((course) => {
+                course.offerings.forEach((offering) => {
+                    offering.Instructor = offering.Instructor.map((instructor) => {
+                        let rmp = UCI.PROFS.getProfessor(instructor);
+                        return {
+                            name: instructor,
+                            rmp
+                        }
+                    })
+                })
+            });
+
+            res.send(results);
+        });
+}
+
 app.post('/api/login', (req, res) => {
     console.log(`[LOGIN REQUEST]`);
     if (req.body.ucinetid_auth) {
@@ -133,6 +153,16 @@ app.get('/api/getCourseDetails', (req, res) => {
     }
 
     getCourseDetails(req.query.course, res);
+});
+
+app.post('/api/searchSchedule', (req, res) => {
+    console.log(`[searchSchedule REQUEST]`);
+    if (!req.body.InstrName && !req.body.CourseCodes && !req.body.Dept && !req.body.Breadth) {
+        res.send('ERROR: You must specify an Instructor, Course Code range, Department, or Breadth category.');
+        return;
+    }
+
+    searchSchedule(req.body, res);
 });
 
 UCI.SOC.init()


### PR DESCRIPTION
For issue #2 
The handler uses the UCI.SOC.searchSchedule function passing on the form body, and then when it gets the results it goes through all the offerings and replaces the professor with an object including a rmp object if they have one. This is pretty inefficient since it goes through all courses, then all offerings then all the instructors so it's O(c*o*i), and it shows when a large department search such as COMPSCI is made it took the request 600ms to process, may need to find a better solution.